### PR TITLE
Fix health check issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac DS_Store
+.DS_Store

--- a/fastdeploy/_app.py
+++ b/fastdeploy/_app.py
@@ -143,41 +143,41 @@ class Infer(object):
 
                             in_data.append(_temp_file_path)
 
-            metrics = {
-                "received": time.time(),
-                "prediction_start": -1,
-                "prediction_end": -1,
-                "batch_size": len(in_data),
-                "predicted_in_batch": -1,
-                "responded": -1,
-            }
+                metrics = {
+                    "received": time.time(),
+                    "prediction_start": -1,
+                    "prediction_end": -1,
+                    "batch_size": len(in_data),
+                    "predicted_in_batch": -1,
+                    "responded": -1,
+                }
 
-            _utils.REQUEST_INDEX[unique_id] = (
-                in_data,
-                metrics,
-                [_extra_options_for_predictor.get(_) for _ in _in_file_names],
-            )
-
-            _utils.META_INDEX["TOTAL_REQUESTS"] += 1
-
-            if is_async_request:
-                resp.media = {"unique_id": unique_id, "success": True}
-                resp.status = falcon.HTTP_200
-            else:
-                preds, status, _metrics = wait_and_read_pred(unique_id)
-
-                if not len(_metrics):
-                    _metrics = metrics
-
-                _metrics["responded"] = time.time()
-                _utils.METRICS_CACHE[len(_utils.METRICS_CACHE)] = (
-                    unique_id,
-                    _metrics,
+                _utils.REQUEST_INDEX[unique_id] = (
                     in_data,
+                    metrics,
+                    [_extra_options_for_predictor.get(_) for _ in _in_file_names],
                 )
 
-                resp.media = preds
-                resp.status = status
+                _utils.META_INDEX["TOTAL_REQUESTS"] += 1
+
+                if is_async_request:
+                    resp.media = {"unique_id": unique_id, "success": True}
+                    resp.status = falcon.HTTP_200
+                else:
+                    preds, status, _metrics = wait_and_read_pred(unique_id)
+
+                    if not len(_metrics):
+                        _metrics = metrics
+
+                    _metrics["responded"] = time.time()
+                    _utils.METRICS_CACHE[len(_utils.METRICS_CACHE)] = (
+                        unique_id,
+                        _metrics,
+                        in_data,
+                    )
+
+                    resp.media = preds
+                    resp.status = status
 
         except Exception as ex:
             _utils.logger.exception(ex, exc_info=True)

--- a/fastdeploy/_loop.py
+++ b/fastdeploy/_loop.py
@@ -10,6 +10,8 @@ IS_FILE_INPUT = _utils.META_INDEX["IS_FILE_INPUT"]
 
 
 def start_loop():
+    _utils.META_INDEX["last_prediction_loop_start_time"] = 0
+
     ACCEPTS_EXTRAS = False
     try:
         from predictor import predictor
@@ -64,7 +66,8 @@ def start_loop():
         first_sleep_start_time = 0
         __loop_is_sleeping = False
         while True:
-            _utils.META_INDEX["predictor_wait_started_at"] = 0
+            _utils.META_INDEX["last_prediction_loop_start_time"] = time.time()
+            
             if len(_utils.REQUEST_INDEX):
                 (
                     unique_id,
@@ -125,7 +128,6 @@ def start_loop():
         try:
             pred_start_time = time.time()
             __in_batch_length = len(batch)
-            _utils.META_INDEX["predictor_wait_started_at"] = time.time()
 
             if ACCEPTS_EXTRAS:
                 preds = predictor(
@@ -133,8 +135,6 @@ def start_loop():
                 )
             else:
                 preds = predictor(batch, batch_size=batch_size)
-
-            _utils.META_INDEX["predictor_wait_started_at"] = 0
 
             if not isinstance(preds, list) or len(preds) != __in_batch_length:
                 _utils.logger.error(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = "https://github.com/notAI-tech/fastDeploy"
 EMAIL = "praneeth@bpraneeth.com"
 AUTHOR = "BEDAPUDI PRANEETH"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "2.2.4"
+VERSION = "2.2.5"
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
If the prediction loop process crashes when `_utils.META_INDEX["predictor_wait_started_at"] = 0` then health check doesn't work. Instead of using the current logic, check when the last time the prediction loop started. So even when the prediction loop crashes, the `_utils.META_INDEX["last_prediction_loop_start_time"]` won't get updated ==> resulting in a stuck case scenario.